### PR TITLE
Add DenseNet to models list

### DIFF
--- a/docs/models.yaml
+++ b/docs/models.yaml
@@ -60,3 +60,10 @@ models:
     size: 445
     reference: https://github.com/tensorflow/models/tree/master/research/object_detection
     demoUrl: 'ssd-inception'
+  -
+    name: DenseNet
+    description: A convnet where outputs from preivous layers are all concatenated, rather than summed, and fed forward to the next layer. Transition layers help reduce the size of the model.
+    type: Computer Vision
+    subtype: Object Detection
+    size: 3840
+    reference: https://github.com/liuzhuang13/DenseNet  

--- a/docs/models.yaml
+++ b/docs/models.yaml
@@ -62,7 +62,7 @@ models:
     demoUrl: 'ssd-inception'
   -
     name: DenseNet
-    description: A convnet where outputs from preivous layers are all concatenated, rather than summed, and fed forward to the next layer. Transition layers help reduce the size of the model.
+    description: A densely connected convolutional network architecture, in which each layer in the network receives signals from all previous layers. The channel-wise inputs to each layer are the concatenated, rather than summed, outputs of previous layers.
     type: Computer Vision
     subtype: Object Detection
     size: 3840


### PR DESCRIPTION
Add DenseNet, a densely-connected CNN model where feature maps of all preceding layers are used as inputs to the current layer.